### PR TITLE
Provide UMD bundle

### DIFF
--- a/docs/vanilla/package.json
+++ b/docs/vanilla/package.json
@@ -6,8 +6,9 @@
   "main": "index.html",
   "scripts": {
     "start": "parcel index.html --open",
+    "start:umd": "parcel umd.html --open",
     "lint": "tsdx lint src; tsc",
-    "build": "parcel build index.html"
+    "build": "parcel build index.html umd.html"
   },
   "dependencies": {
     "embla-carousel": "^6.0.1",

--- a/docs/vanilla/src/js/index.ts
+++ b/docs/vanilla/src/js/index.ts
@@ -1,7 +1,4 @@
-import '../css/base.css'
-import '../css/reset.css'
-import '../css/embla.css'
-import '../css/radio.css'
+import './styles'
 // Adds support old IE >= 10
 import 'core-js/stable'
 import 'events-polyfill/src/constructors/MouseEvent'

--- a/docs/vanilla/src/js/styles.ts
+++ b/docs/vanilla/src/js/styles.ts
@@ -1,0 +1,4 @@
+import '../css/base.css'
+import '../css/reset.css'
+import '../css/embla.css'
+import '../css/radio.css'

--- a/docs/vanilla/umd.html
+++ b/docs/vanilla/umd.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Embla Carousel (UMD) - with wheel gestures</title>
+    <meta charset="UTF-8" />
+
+    <link rel="stylesheet" href="src/css/base.css" />
+    <link rel="stylesheet" href="src/css/reset.css" />
+    <link rel="stylesheet" href="src/css/embla.css" />
+    <link rel="stylesheet" href="src/css/radio.css" />
+  </head>
+
+  <body>
+    <div class="content">
+      <!-- Embla -->
+      <div class="embla">
+        <div class="embla__viewport">
+          <div class="embla__container">
+            <div class="embla__slide">
+              <div class="embla__slide__inner"></div>
+            </div>
+            <div class="embla__slide">
+              <div class="embla__slide__inner"></div>
+            </div>
+            <div class="embla__slide">
+              <div class="embla__slide__inner"></div>
+            </div>
+            <div class="embla__slide">
+              <div class="embla__slide__inner"></div>
+            </div>
+            <div class="embla__slide">
+              <div class="embla__slide__inner"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Script -->
+    <script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js"></script>
+    <script src="https://unpkg.com/embla-carousel-wheel-gestures/dist/embla-carousel-wheel-gestures.umd.js"></script>
+    <script type="text/javascript">
+      var emblaNode = document.querySelector('.embla__viewport')
+      var options = { loop: false, skipSnaps: true }
+      var plugins = [EmblaCarouselWheelGestures()]
+      var embla = EmblaCarousel(emblaNode, options, plugins)
+    </script>
+  </body>
+</html>

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -1,7 +1,7 @@
 {
   "name": "embla-carousel-wheel-gestures",
   "private": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "wheel gestures for embla carousel",
   "main": "dist/index.js",
   "module": "dist/embla-carousel-wheel-gestures.esm.js",

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -1,7 +1,7 @@
 {
   "name": "embla-carousel-wheel-gestures",
   "private": false,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "wheel gestures for embla carousel",
   "main": "dist/index.js",
   "module": "dist/embla-carousel-wheel-gestures.esm.js",

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build",
+    "build": "tsdx build --format cjs,esm,umd",
     "test": "tsdx test",
     "lint": "tsdx lint src",
     "prepare": "tsdx build",

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -80,16 +80,16 @@
   "bundlewatch": {
     "files": [
       {
+        "path": "dist/*.js",
+        "maxSize": "1.5kB"
+      },
+      {
         "path": "dist/embla-carousel-wheel-gestures.umd.development.js",
         "maxSize": "6kB"
       },
       {
         "path": "dist/embla-carousel-wheel-gestures.umd.js",
         "maxSize": "3kB"
-      },
-      {
-        "path": "dist/*.js",
-        "maxSize": "1.5kB"
       }
     ]
   }

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -18,7 +18,7 @@
     "build": "tsdx build --format cjs,esm,umd",
     "test": "tsdx test",
     "lint": "tsdx lint src",
-    "prepare": "tsdx build",
+    "prepare": "tsdx build --format cjs,esm,umd",
     "prepublishOnly": "cp ../README.md README.md"
   },
   "husky": {
@@ -79,6 +79,14 @@
   },
   "bundlewatch": {
     "files": [
+      {
+        "path": "dist/embla-carousel-wheel-gestures.umd.development.js",
+        "maxSize": "6kB"
+      },
+      {
+        "path": "dist/embla-carousel-wheel-gestures.umd.js",
+        "maxSize": "3kB"
+      },
       {
         "path": "dist/*.js",
         "maxSize": "1.5kB"

--- a/embla-carousel-wheel-gestures/src/umd.ts
+++ b/embla-carousel-wheel-gestures/src/umd.ts
@@ -1,0 +1,1 @@
+export { WheelGesturesPlugin as default } from './WheelGesturesPlugin'

--- a/embla-carousel-wheel-gestures/tsdx.config.js
+++ b/embla-carousel-wheel-gestures/tsdx.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  rollup(config) {
+    if (config.output.format === 'umd') {
+      const origExternal = config.external
+
+      // UMD is better served by a default export
+      config.input = config.input.replace('/index.ts', '/umd.ts')
+      config.output.exports = 'default'
+      config.output.name = 'EmblaCarouselWheelGestures'
+      config.output.file = config.output.file.replace('.umd.production.min.js', '.umd.js')
+
+      config.external = (id) => {
+        // Dependencies to be bundled into the UMD file
+        if (id === 'wheel-gestures') {
+          return false
+        }
+        return origExternal(id)
+      }
+    }
+
+    return config
+  },
+}


### PR DESCRIPTION
- Exports for CJS and ESM modules stay the same
- Adds an UMD bundle to the distributed package, so it can be included via unpkg etc. (fixes #147)
- The plugin is exposed as `EmblaCarouselWheelGestures` on the global object (`window`), when embedding the UMD bundle using a script tag

### Usage

```html
<script src="https://unpkg.com/embla-carousel-wheel-gestures/dist/embla-carousel-wheel-gestures.umd.js"></script>
<script type="text/javascript">
  EmblaCarousel(document.querySelector('.embla__viewport'), { skipSnaps: true }, [
    EmblaCarouselWheelGestures(),
  ])
</script>
```

[UMD Demo](https://embla-carousel-wheel-gestures-git-umd-xiel.vercel.app/umd.html)