### PR TITLE
Adapt for the new embla-carousel v7

### DIFF
--- a/docs/react/package.json
+++ b/docs/react/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
-    "embla-carousel-react": "^6.2.0",
+    "embla-carousel-react": "^7.0.0-rc03",
     "embla-carousel-wheel-gestures": "^2.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/docs/vanilla/package.json
+++ b/docs/vanilla/package.json
@@ -11,7 +11,7 @@
     "build": "parcel build index.html umd.html shadow.html --no-cache"
   },
   "dependencies": {
-    "embla-carousel": "^6.2.0",
+    "embla-carousel": "^7.0.0-rc03",
     "embla-carousel-wheel-gestures": "^2.2.0",
     "events-polyfill": "^2.1.2",
     "core-js": "^3.11.1"

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/xiel/embla-carousel-wheel-gestures#readme",
   "peerDependencies": {
-    "embla-carousel": "^7.0.0-rc01"
+    "embla-carousel": "^7.0.0-rc03"
   },
   "dependencies": {
     "wheel-gestures": "^2.2.5"
@@ -57,7 +57,7 @@
     "@testing-library/react": "^11.2.6",
     "@types/jest": "^26.0.23",
     "bundlewatch": "^0.3.2",
-    "embla-carousel": "^7.0.0-rc01",
+    "embla-carousel": "^7.0.0-rc03",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-app": "^6.2.2",

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/xiel/embla-carousel-wheel-gestures#readme",
   "peerDependencies": {
-    "embla-carousel": "^6.0.1"
+    "embla-carousel": "^7.0.0-rc01"
   },
   "dependencies": {
     "wheel-gestures": "^2.2.5"
@@ -57,7 +57,7 @@
     "@testing-library/react": "^11.2.6",
     "@types/jest": "^26.0.23",
     "bundlewatch": "^0.3.2",
-    "embla-carousel": "^6.2.0",
+    "embla-carousel": "^7.0.0-rc01",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-app": "^6.2.2",

--- a/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
+++ b/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
@@ -155,7 +155,7 @@ export function WheelGesturesPlugin(userOptions?: WheelGesturesPluginUserOptions
   }
 
   const self: WheelGesturesPluginType = {
-    name: 'wheel-gestures',
+    name: 'wheelGestures',
     options: optionsHandler.merge(optionsBase, userOptions),
     init,
     destroy: () => cleanup(),

--- a/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
+++ b/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
@@ -1,15 +1,20 @@
-import { EmblaCarouselType, EmblaPluginType } from 'embla-carousel'
+import EmblaCarousel, { EmblaCarouselType } from 'embla-carousel'
+import { CreateOptionsType } from 'embla-carousel/components/Options'
+import { CreatePluginType } from 'embla-carousel/components/Plugins'
 import WheelGestures, { WheelEventState } from 'wheel-gestures'
 
-export type WheelGesturesPluginOptions = {
+export type WheelGesturesPluginOptions = CreateOptionsType<{
   wheelDraggingClass: string
   forceWheelAxis?: 'x' | 'y'
   target?: Element
-}
+}>
+
 type WheelGesturesPluginUserOptions = Partial<WheelGesturesPluginOptions>
-type WheelGesturesPluginType = EmblaPluginType<WheelGesturesPluginOptions>
+type WheelGesturesPluginType = CreatePluginType<{}, WheelGesturesPluginOptions>
 
 const defaultOptions: WheelGesturesPluginOptions = {
+  active: true,
+  breakpoints: {},
   wheelDraggingClass: 'is-wheel-dragging',
   forceWheelAxis: undefined,
   target: undefined,
@@ -20,15 +25,14 @@ WheelGesturesPlugin.globalOptions = undefined as WheelGesturesPluginUserOptions 
 const __DEV__ = process.env.NODE_ENV !== 'production'
 
 export function WheelGesturesPlugin(userOptions?: WheelGesturesPluginUserOptions): WheelGesturesPluginType {
-  const options: WheelGesturesPluginOptions = {
-    ...defaultOptions,
-    ...WheelGesturesPlugin.globalOptions,
-    ...userOptions,
-  }
+  const optionsHandler = EmblaCarousel.optionsHandler()
+  const optionsBase = optionsHandler.merge(defaultOptions, WheelGesturesPlugin.globalOptions)
+  let options: WheelGesturesPluginType['options']
 
   let cleanup = () => {}
 
   function init(embla: EmblaCarouselType) {
+    options = optionsHandler.atMedia(self.options)
     const engine = embla.internalEngine()
     const targetNode = options.target ?? (embla.containerNode().parentNode as Element)
     const wheelAxis = options.forceWheelAxis ?? engine.options.axis
@@ -150,10 +154,11 @@ export function WheelGesturesPlugin(userOptions?: WheelGesturesPluginUserOptions
     }
   }
 
-  return {
+  const self: WheelGesturesPluginType = {
     name: 'wheel-gestures',
+    options: optionsHandler.merge(optionsBase, userOptions),
     init,
     destroy: () => cleanup(),
-    options,
   }
+  return self
 }

--- a/embla-carousel-wheel-gestures/test/options.test.ts
+++ b/embla-carousel-wheel-gestures/test/options.test.ts
@@ -4,6 +4,8 @@ test('Passed options merged with defaults', () => {
   const wheelGestures = WheelGesturesPlugin({ forceWheelAxis: 'y', target: document.body })
   expect(wheelGestures.options).toMatchInlineSnapshot(`
     Object {
+      "active": true,
+      "breakpoints": Object {},
       "forceWheelAxis": "y",
       "target": <body />,
       "wheelDraggingClass": "is-wheel-dragging",
@@ -15,6 +17,8 @@ test('No passed options, no global options', () => {
   const wheelGestures = WheelGesturesPlugin()
   expect(wheelGestures.options).toMatchInlineSnapshot(`
     Object {
+      "active": true,
+      "breakpoints": Object {},
       "forceWheelAxis": undefined,
       "target": undefined,
       "wheelDraggingClass": "is-wheel-dragging",
@@ -37,6 +41,8 @@ test('Global options are merged correctly', () => {
 
   expect(wheelGestures.options).toMatchInlineSnapshot(`
     Object {
+      "active": true,
+      "breakpoints": Object {},
       "forceWheelAxis": "x",
       "target": undefined,
       "wheelDraggingClass": "abc",
@@ -44,6 +50,8 @@ test('Global options are merged correctly', () => {
   `)
   expect(wheelGestures2.options).toMatchInlineSnapshot(`
     Object {
+      "active": true,
+      "breakpoints": Object {},
       "forceWheelAxis": "x",
       "target": <body />,
       "wheelDraggingClass": "passed-class",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,11 @@ embla-carousel@6.2.0, embla-carousel@^6.2.0:
   resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-6.2.0.tgz#c16b18abe50e05ccd03d0b8d0b738f6a87aea1e0"
   integrity sha512-dSNsiQ7nmSQJZgbYfZCLdzrnznHwpaAcdJFcMRKgm/pjH1doOgxmfsvlMy4VfO4J11hLz8jm/W8WxSSDqfuu4w==
 
+embla-carousel@^7.0.0-rc01:
+  version "7.0.0-rc01"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-7.0.0-rc01.tgz#7c9adfd7302b85c2de9354b7ef6343f16a696eb7"
+  integrity sha512-IBTSKcPw7u9K0zoLvsnWYsijKsI0msFqzNp6ASIthTXiMZNJNGQt8k0ax7KqUVinDZeNM07WPWqYsjrvUM/Epw==
+
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,19 +3329,14 @@ electron-to-chromium@^1.4.84:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz#ebe6a2573b563680c7a7bf3a51b9e465c9c501db"
   integrity sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q==
 
-embla-carousel-react@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-6.2.0.tgz#25fbba759b294b54d6241a04ff56dca83bd3c511"
-  integrity sha512-XshB7pmmhso/fzENefflWw5/N3HqCjO8H5CkzQxuCQqV9w+bvEaBkjUZ6fxfqLUMMSKFWIQvMD6uo9f8oKS+2g==
+embla-carousel-react@^7.0.0-rc03:
+  version "7.0.0-rc03"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-7.0.0-rc03.tgz#6adf04a820bff5c49b72969f63b98f74bb6504dd"
+  integrity sha512-6Vu9H/5BDqr6TJFBKc0R2z/UWrvbgueRZhIwvquuDo4EDr6xxhVCjUfOUlDsz6zNJrOSysWfl9zPMtZ7oIUFog==
   dependencies:
-    embla-carousel "6.2.0"
+    embla-carousel "7.0.0-rc03"
 
-embla-carousel@6.2.0, embla-carousel@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-6.2.0.tgz#c16b18abe50e05ccd03d0b8d0b738f6a87aea1e0"
-  integrity sha512-dSNsiQ7nmSQJZgbYfZCLdzrnznHwpaAcdJFcMRKgm/pjH1doOgxmfsvlMy4VfO4J11hLz8jm/W8WxSSDqfuu4w==
-
-embla-carousel@^7.0.0-rc03:
+embla-carousel@7.0.0-rc03, embla-carousel@^7.0.0-rc03:
   version "7.0.0-rc03"
   resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-7.0.0-rc03.tgz#7af5d4af2292228c005f91979f7d34ba0d94f709"
   integrity sha512-2BQ58/E7hJBmnjxBTOrjcrWcXGN1qQBgwCf2uMIer6/r5OlyFXSqLPd1lq3c/RJA9V5qp3qnfm8mU4hSJS8UWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,10 +3341,10 @@ embla-carousel@6.2.0, embla-carousel@^6.2.0:
   resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-6.2.0.tgz#c16b18abe50e05ccd03d0b8d0b738f6a87aea1e0"
   integrity sha512-dSNsiQ7nmSQJZgbYfZCLdzrnznHwpaAcdJFcMRKgm/pjH1doOgxmfsvlMy4VfO4J11hLz8jm/W8WxSSDqfuu4w==
 
-embla-carousel@^7.0.0-rc01:
-  version "7.0.0-rc01"
-  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-7.0.0-rc01.tgz#7c9adfd7302b85c2de9354b7ef6343f16a696eb7"
-  integrity sha512-IBTSKcPw7u9K0zoLvsnWYsijKsI0msFqzNp6ASIthTXiMZNJNGQt8k0ax7KqUVinDZeNM07WPWqYsjrvUM/Epw==
+embla-carousel@^7.0.0-rc03:
+  version "7.0.0-rc03"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-7.0.0-rc03.tgz#7af5d4af2292228c005f91979f7d34ba0d94f709"
+  integrity sha512-2BQ58/E7hJBmnjxBTOrjcrWcXGN1qQBgwCf2uMIer6/r5OlyFXSqLPd1lq3c/RJA9V5qp3qnfm8mU4hSJS8UWA==
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
* Adapt the wheel gestures plugin for [embla-carousel v7](https://github.com/davidjerleke/embla-carousel/releases/tag/v7.0.0-rc01).
* Changes inspired by the equivalent changes in the bundled plugins for v7 ([example](https://github.com/davidjerleke/embla-carousel/blob/master/packages/embla-carousel-autoplay/src/components/index.ts)).