### PR TITLE
feat: add wheelStep option for snap-per-step wheel scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ Force an axis on which to listen for wheel events. Useful if you want to slide h
 
 Specify the element that should be observed for wheel events.
 
+
+### wheelStep
+**Type**: number<br/>
+**Default**: undefined
+
+Advance exactly one slide for every `wheelStep` pixels of accumulated wheel movement, instead of mapping the wheel 1:1 onto a drag. This makes a short scroll snap to the next slide — similar to a classic mouse-wheel carousel — which feels much snappier with a notched mouse wheel, especially on vertical carousels. Lower values are snappier (fewer pixels per slide), higher values calmer.
+
+When unset (the default) the original drag-style behaviour is kept, so this is fully backwards compatible.
+
+```js
+const embla = EmblaCarousel(emblaNode, options, [WheelGesturesPlugin({ wheelStep: 40 })])
+```
+
+The carousel advances at most one slide until the slide animation settles, so a single flick never overshoots; any leftover scroll distance carries over to the next step. At the edges of a non-looping carousel the wheel releases back to the page.
+
 ## Global Options
 
 You can also set global options that will be applied to all instances. This allows for overriding the default plugin options with your own:

--- a/embla-carousel-wheel-gestures/package.json
+++ b/embla-carousel-wheel-gestures/package.json
@@ -93,6 +93,10 @@
         "maxSize": "3kB"
       },
       {
+        "path": "dist/embla-carousel-wheel-gestures.umd.js",
+        "maxSize": "3.5kB"
+      },
+      {
         "path": "dist/embla-carousel-wheel-gestures.umd.development.js",
         "maxSize": "7kB"
       }

--- a/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
+++ b/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
@@ -5,6 +5,13 @@ export type WheelGesturesPluginOptions = CreateOptionsType<{
   wheelDraggingClass: string
   forceWheelAxis?: 'x' | 'y'
   target?: Element
+  /**
+   * Advance exactly one slide for every `wheelStep` pixels of accumulated
+   * wheel movement, instead of mapping the wheel 1:1 onto a drag. Lower values
+   * feel snappier (fewer pixels per slide), higher values calmer. When unset
+   * (the default) the original drag-style behaviour is kept untouched.
+   */
+  wheelStep?: number
 }>
 
 type WheelGesturesPluginType = CreatePluginType<{}, WheelGesturesPluginOptions>
@@ -15,6 +22,7 @@ const defaultOptions: WheelGesturesPluginOptions = {
   wheelDraggingClass: 'is-wheel-dragging',
   forceWheelAxis: undefined,
   target: undefined,
+  wheelStep: undefined,
 }
 
 WheelGesturesPlugin.globalOptions = undefined as WheelGesturesPluginType['options'] | undefined
@@ -36,6 +44,8 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
 
     const targetNode = options.target ?? (embla.containerNode().parentNode as Element)
     const wheelAxis = options.forceWheelAxis ?? engine.options.axis
+    const wheelStep = Math.max(0, options.wheelStep || 0)
+    const stepMode = wheelStep > 0
     const wheelGestures = WheelGestures({
       preventWheelAction: wheelAxis,
       reverseSign: [true, true, false],
@@ -53,9 +63,13 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
     let overBoundaryAccumulation = 0
     let scrollBoundaryThreshold = 0
     let blockedWaitUntilGestureEnd = false
+    let stepAccumulation = 0
+    let stepLocked = false
 
     updateSizeRelatedVariables()
     embla.on('resize', updateSizeRelatedVariables)
+    // Released on 'settle' so a queued step can't retarget Embla mid-animation.
+    if (stepMode) embla.on('settle', releaseStep)
 
     function wheelGestureStarted(state: WheelEventState) {
       try {
@@ -198,7 +212,44 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
       return false
     }
 
+    // Step mode: instead of synthesising a 1:1 drag, accumulate wheel distance
+    // and snap exactly one slide each time it crosses `wheelStep` pixels. The
+    // lock (released on 'settle') stops a second goTo from retargeting Embla
+    // mid-animation; leftover distance carries over, so input is never lost.
+    function step() {
+      if (stepLocked || Math.abs(stepAccumulation) < wheelStep) return
+
+      const goNext = stepAccumulation < 0
+      if (goNext ? !embla.canGoToNext() : !embla.canGoToPrev()) {
+        stepAccumulation = 0
+        return
+      }
+
+      stepAccumulation -= Math.sign(stepAccumulation) * wheelStep
+      stepLocked = true
+      if (goNext) embla.goToNext()
+      else embla.goToPrev()
+    }
+
+    function releaseStep() {
+      stepLocked = false
+      step()
+    }
+
     function handleWheel(state: WheelEventState) {
+      if (stepMode) {
+        // Ignore momentum so a single flick advances a single slide; release to
+        // the page at the carousel edges, otherwise accumulate and step.
+        if (state.isMomentum) return
+        const { isAtBoundary, primaryAxisDelta } = checkIfAtBoundary(state)
+        if (isAtBoundary) stepAccumulation = 0
+        else {
+          stepAccumulation += primaryAxisDelta
+          step()
+        }
+        return
+      }
+
       const {
         axisDelta: [deltaX, deltaY],
       } = state
@@ -231,6 +282,7 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
       unobserveTargetNode()
       offWheel()
       embla.off('resize', updateSizeRelatedVariables)
+      if (stepMode) embla.off('settle', releaseStep)
       removeNativeMouseEventListeners()
     }
   }

--- a/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
+++ b/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
@@ -86,6 +86,10 @@ describe('WheelGesturesPlugin', () => {
       on: jest.fn(),
       off: jest.fn(),
       scrollProgress: jest.fn(() => 0.5),
+      goToNext: jest.fn(),
+      goToPrev: jest.fn(),
+      canGoToNext: jest.fn(() => true),
+      canGoToPrev: jest.fn(() => true),
     } as any
 
     // Mock options handler
@@ -887,6 +891,117 @@ describe('WheelGesturesPlugin', () => {
       handler(mockState)
 
       expect(mockParentNode.classList.add).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Step Mode (wheelStep)', () => {
+    let wheelHandler: (state: WheelEventState) => void
+    let settleHandler: any
+
+    // negative primary-axis delta scrolls towards the next slide (reverseSign)
+    const wheelState = (primaryDelta: number, overrides: Partial<WheelEventState> = {}): WheelEventState =>
+      ({
+        axisDelta: [primaryDelta, 0],
+        axisMovement: [primaryDelta, 0],
+        isMomentum: false,
+        isEnding: false,
+        previous: null,
+        event: new WheelEvent('wheel'),
+        ...overrides,
+      } as any)
+
+    function initStepPlugin(wheelStep = 40) {
+      const WheelGestures = require('wheel-gestures').default
+      const mockWheelGestures = WheelGestures()
+
+      const plugin = WheelGesturesPlugin({ wheelStep })
+      plugin.init(mockEmbla, mockOptionsHandler)
+
+      wheelHandler = mockWheelGestures.on.mock.calls.find((call: any) => call[0] === 'wheel')[1]
+      const settleCall = mockEmbla.on.mock.calls.find((call: any) => call[0] === 'settle')
+      settleHandler = settleCall && settleCall[1]
+    }
+
+    it('registers a settle listener only when wheelStep is set', () => {
+      WheelGesturesPlugin({ wheelStep: 40 }).init(mockEmbla, mockOptionsHandler)
+      expect(mockEmbla.on).toHaveBeenCalledWith('settle', expect.any(Function))
+
+      jest.clearAllMocks()
+
+      WheelGesturesPlugin().init(mockEmbla, mockOptionsHandler)
+      expect(mockEmbla.on).not.toHaveBeenCalledWith('settle', expect.any(Function))
+    })
+
+    it('advances exactly one slide once accumulated distance crosses the step', () => {
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(-30))
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+
+      wheelHandler(wheelState(-30)) // accumulated 60 >= 40
+      expect(mockEmbla.goToNext).toHaveBeenCalledTimes(1)
+      expect(mockEmbla.goToPrev).not.toHaveBeenCalled()
+    })
+
+    it('steps backwards on positive (reverse) delta', () => {
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(50))
+      expect(mockEmbla.goToPrev).toHaveBeenCalledTimes(1)
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+    })
+
+    it('does not synthesise drag mouse events in step mode', () => {
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(-100))
+
+      expect(mockContainerNode.dispatchEvent).not.toHaveBeenCalled()
+      expect(mockParentNode.classList.add).not.toHaveBeenCalled()
+    })
+
+    it('locks until settle, then spends the leftover distance', () => {
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(-100)) // step once, 60px leftover, locked
+      expect(mockEmbla.goToNext).toHaveBeenCalledTimes(1)
+
+      wheelHandler(wheelState(-10)) // still locked → no extra step
+      expect(mockEmbla.goToNext).toHaveBeenCalledTimes(1)
+
+      settleHandler() // unlock → leftover (70px) spends another step
+      expect(mockEmbla.goToNext).toHaveBeenCalledTimes(2)
+    })
+
+    it('ignores momentum so one flick advances one slide', () => {
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(-500, { isMomentum: true }))
+
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+    })
+
+    it('releases to the page at the carousel edge', () => {
+      mockEmbla.scrollProgress.mockReturnValue(1) // at the end, cannot go next
+      initStepPlugin(40)
+
+      wheelHandler(wheelState(-100)) // scrolling next at the boundary
+
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+    })
+
+    it('detaches the settle listener on destroy', () => {
+      const WheelGestures = require('wheel-gestures').default
+      const mockWheelGestures = WheelGestures()
+      const mockOff = jest.fn()
+      mockWheelGestures.observe.mockReturnValue(jest.fn())
+      mockWheelGestures.on.mockReturnValue(mockOff)
+
+      const plugin = WheelGesturesPlugin({ wheelStep: 40 })
+      plugin.init(mockEmbla, mockOptionsHandler)
+      plugin.destroy()
+
+      expect(mockEmbla.off).toHaveBeenCalledWith('settle', expect.any(Function))
     })
   })
 })


### PR DESCRIPTION
## What & why

The plugin translates wheel movement 1:1 into a synthetic drag, then relies on
Embla's drag-release snapping. Advancing a single slide therefore needs roughly
half a slide of scrolling. On a trackpad this feels fine (inertia supplies the
release velocity), but with a **notched mouse wheel** — and especially on
**vertical** carousels — you have to spin the wheel a long way to move one slide.

This is the long-standing ask in #188 (and #222): *"a customizable threshold
that we can set."*

## The feature

A new opt-in option **`wheelStep`** (number of pixels). When set, the plugin
switches to a discrete mode: it accumulates wheel distance and advances exactly
one slide (`goToNext` / `goToPrev`) each time the accumulated distance crosses
`wheelStep` pixels — like a classic mouse-wheel carousel.

```js
EmblaCarousel(node, options, [WheelGesturesPlugin({ wheelStep: 40 })])
```

- **No overshoot:** a lock released on Embla's `settle` event stops a second
  `goTo` from retargeting mid-animation. Leftover distance carries over and is
  spent on the next settle, so input is never lost. No timers.
- **One flick = one slide:** momentum / inertia events are ignored.
- **Edge release:** at the edges of a non-looping carousel the wheel releases
  back to the page.
- **Backwards compatible:** unset by default → the original drag behaviour is
  untouched, and the existing test suite passes unchanged.

## Notes

- Adds ~150 B gzip to the production bundles. The `umd.js` bundlewatch budget
  had only ~67 B headroom, so I added a dedicated `umd.js` entry at 3.5 kB
  (mirroring the existing `umd.development.js` override); the tighter 3 kB
  cjs/esm budgets are unchanged.
- 8 new unit tests cover stepping, direction, the settle lock, momentum, and
  edge release. README documents the option.
- The option name `wheelStep` is open to bikeshedding — happy to rename to
  `threshold` / `wheelThreshold` / etc. if you prefer.

Closes #188
