### PR TITLE
fix: apply boundary damping to the scroll axis in WheelGesturesPlugin

### DIFF
--- a/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
+++ b/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
@@ -125,12 +125,18 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
         // Calculate progressive damping factor based on how far over boundary we are
         const progressRatio = Math.min(overBoundaryAccumulation / scrollBoundaryThreshold, 1)
         const dampingFactor = 0.25 + progressRatio * 0.5
-        const counterMoveSign = moveX > 0 ? -1 : 1
+        // a vertical carousel scrolls on moveY, so the damping cannot always use moveX
+        const isVerticalCarousel = engine.options.axis === 'y'
+        const scrollAxisMovement = isVerticalCarousel ? moveY : moveX
+        const counterMoveSign = scrollAxisMovement > 0 ? -1 : 1
         const counterMovement = overBoundaryAccumulation * counterMoveSign
         const dampingMovement = counterMovement * dampingFactor
 
-        moveX += dampingMovement
-        moveY += dampingMovement
+        if (isVerticalCarousel) {
+          moveY += dampingMovement
+        } else {
+          moveX += dampingMovement
+        }
       }
 
       // prevent skipping slides

--- a/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
+++ b/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
@@ -502,6 +502,98 @@ describe('WheelGesturesPlugin', () => {
     })
   })
 
+  describe('Boundary Damping', () => {
+    function initPluginWithAxis(axis: string) {
+      mockEngine.options.axis = axis
+
+      const WheelGestures = require('wheel-gestures').default
+      const mockWheelGestures = WheelGestures()
+
+      WheelGesturesPlugin().init(mockEmbla, mockOptionsHandler)
+
+      return mockWheelGestures.on.mock.calls.find((call: any) => call[0] === 'wheel')[1]
+    }
+
+    it('should damp the movement of a vertical carousel at the start boundary', () => {
+      const wheelHandler = initPluginWithAxis('y')
+
+      const startState: WheelEventState = {
+        axisDelta: [0, 20],
+        axisMovement: [0, 20],
+        isMomentum: false,
+        isEnding: false,
+        previous: null,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      wheelHandler(startState)
+      jest.clearAllMocks()
+
+      // no previous slides left, so scrolling further back is over the boundary
+      mockEmbla.scrollProgress.mockReturnValue(0)
+
+      const boundaryState: WheelEventState = {
+        axisDelta: [0, 60],
+        axisMovement: [0, 60],
+        isMomentum: false,
+        isEnding: false,
+        previous: startState,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      wheelHandler(boundaryState)
+
+      // the threshold is half the container height (300), so being 60px over it
+      // damps by 60 * (0.25 + 0.2 * 0.5) = 21, against the movement
+      expect(MouseEvent).toHaveBeenCalledWith(
+        'mousemove',
+        expect.objectContaining({
+          movementX: 0,
+          movementY: 39,
+        })
+      )
+    })
+
+    it('should not damp the cross axis', () => {
+      const wheelHandler = initPluginWithAxis('x')
+
+      const startState: WheelEventState = {
+        axisDelta: [20, 0],
+        axisMovement: [20, 0],
+        isMomentum: false,
+        isEnding: false,
+        previous: null,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      wheelHandler(startState)
+      jest.clearAllMocks()
+
+      mockEmbla.scrollProgress.mockReturnValue(0)
+
+      const boundaryState: WheelEventState = {
+        axisDelta: [80, 0],
+        axisMovement: [100, 5],
+        isMomentum: false,
+        isEnding: false,
+        previous: startState,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      wheelHandler(boundaryState)
+
+      // the threshold is half the container width (400), so being 80px over it damps
+      // the scroll axis by 80 * (0.25 + 0.2 * 0.5) = 28 and leaves the cross axis alone
+      expect(MouseEvent).toHaveBeenCalledWith(
+        'mousemove',
+        expect.objectContaining({
+          movementX: 72,
+          movementY: 5,
+        })
+      )
+    })
+  })
+
   describe('Mouse Event Creation', () => {
     let plugin: any
     let wheelHandler: (state: WheelEventState) => void


### PR DESCRIPTION
The boundary damping uses `moveX` for the direction and then adds the result to both axes.

But `moveX` and `moveY` are mapped to the carousel axes a few lines above. On a vertical carousel `moveX` is the cross axis, and it is normally 0. So the sign is always `+1`. At the start boundary the damping then pushes the movement further out of bounds instead of holding it back. The cross axis also gets a damping value that it should not get.

Numbers from the mocked engine (vertical carousel, start boundary, movement +60px, 60px over the boundary):

| | movementX | movementY |
| --- | --- | --- |
| before | 21 | 81 |
| after | 0 | 39 |

A horizontal carousel keeps the same value on the scroll axis. It only loses the extra movement on the cross axis. So nothing changes there.

I added two tests. They are the first tests in the suite with a vertical carousel. That is probably why nobody saw this: on a horizontal carousel `moveX` is the scroll axis, so the sign is correct by luck.

`test`, `lint` and `build` pass here. Gzipped `umd.js` goes from 3005 to 3016 bytes (bundlewatch limit is 3072).
