### PR TITLE
fix: move one slide when a gesture has a single wheel event

### DIFF
--- a/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
+++ b/embla-carousel-wheel-gestures/src/WheelGesturesPlugin.ts
@@ -53,6 +53,7 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
     let overBoundaryAccumulation = 0
     let scrollBoundaryThreshold = 0
     let blockedWaitUntilGestureEnd = false
+    let movementEventCount = 0
 
     updateSizeRelatedVariables()
     embla.on('resize', updateSizeRelatedVariables)
@@ -73,6 +74,7 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
 
       isStarted = true
       overBoundaryAccumulation = 0
+      movementEventCount = 0
       addNativeMouseEventListeners()
 
       if (options.wheelDraggingClass) {
@@ -222,7 +224,20 @@ export function WheelGesturesPlugin(userOptions: WheelGesturesPluginType['option
 
       if (isEndingOrRelease) {
         wheelGestureEnded(state)
+
+        // a gesture of one wheel event has no measurable drag speed, so embla would
+        // always settle back on the slide the gesture started on
+        if (movementEventCount === 1 && !engine.options.dragFree) {
+          const [movementX, movementY] = state.axisMovement
+
+          if ((wheelAxis === 'x' ? movementX : movementY) < 0) {
+            embla.goToNext()
+          } else {
+            embla.goToPrev()
+          }
+        }
       } else {
+        movementEventCount += 1
         dispatchEvent(createRelativeMouseEvent('mousemove', state))
       }
     }

--- a/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
+++ b/embla-carousel-wheel-gestures/test/WheelGesturesPlugin.test.ts
@@ -86,6 +86,8 @@ describe('WheelGesturesPlugin', () => {
       on: jest.fn(),
       off: jest.fn(),
       scrollProgress: jest.fn(() => 0.5),
+      goToNext: jest.fn(),
+      goToPrev: jest.fn(),
     } as any
 
     // Mock options handler
@@ -360,6 +362,64 @@ describe('WheelGesturesPlugin', () => {
 
       expect(mockContainerNode.dispatchEvent).toHaveBeenCalled()
       expect(mockParentNode.classList.remove).toHaveBeenCalledWith('is-wheel-dragging')
+    })
+
+    // a gesture made of one wheel event has no measurable drag speed, so embla
+    // would always snap back to the slide the gesture started on
+    function singleWheelEventGesture(primaryAxisDelta: number) {
+      const wheelState: WheelEventState = {
+        axisDelta: [primaryAxisDelta, 0],
+        axisMovement: [primaryAxisDelta, 0],
+        isMomentum: false,
+        isEnding: false,
+        previous: null,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      const endState: WheelEventState = {
+        axisDelta: [0, 0],
+        axisMovement: [primaryAxisDelta, 0],
+        isMomentum: false,
+        isEnding: true,
+        previous: wheelState,
+        event: new WheelEvent('wheel'),
+      } as any
+
+      return [wheelState, endState]
+    }
+
+    it('should scroll to the next slide when a single wheel event scrolled forward', () => {
+      singleWheelEventGesture(-120).forEach(wheelHandler)
+
+      expect(mockEmbla.goToNext).toHaveBeenCalled()
+      expect(mockEmbla.goToPrev).not.toHaveBeenCalled()
+    })
+
+    it('should scroll to the previous slide when a single wheel event scrolled back', () => {
+      singleWheelEventGesture(120).forEach(wheelHandler)
+
+      expect(mockEmbla.goToPrev).toHaveBeenCalled()
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+    })
+
+    it('should not scroll when the gesture had more than one wheel event', () => {
+      const [wheelState, endState] = singleWheelEventGesture(-120)
+
+      wheelHandler(wheelState)
+      wheelHandler({ ...wheelState, axisMovement: [-240, 0] } as any)
+      wheelHandler(endState)
+
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+      expect(mockEmbla.goToPrev).not.toHaveBeenCalled()
+    })
+
+    it('should not scroll a dragFree carousel, which keeps the position it was dragged to', () => {
+      mockEngine.options.dragFree = true
+
+      singleWheelEventGesture(-120).forEach(wheelHandler)
+
+      expect(mockEmbla.goToNext).not.toHaveBeenCalled()
+      expect(mockEmbla.goToPrev).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
A notched mouse wheel sends one wheel event per click. The plugin then sends `mousedown` and one `mousemove` in the same moment. The gesture only ends 400ms later.

Embla ignores a drag speed if it was measured more than 170ms before the `mouseup`. And two events from the same moment have no speed at all. So embla only looks at the drag position: 120px. That is less than the 50% it needs for the next slide, so the carousel always goes back to the slide where it started. One wheel click does nothing.

This case cannot work with the emulated drag, so I move one slide in the wheel direction instead.

Gestures with more than one wheel event are not touched. There the 400ms window is useful, because the movement adds up. `dragFree` carousels are also not touched, because they keep the position they were dragged to, which is correct.

Small detail: the direction comes from `axisMovement`, not from `axisDelta`. The end state from `wheel-gestures` has `axisDelta: [0, 0, 0]`.

I added four tests.

This does not collide with #233. `wheelStep` changes how all wheel movement maps to slides. This change only replaces a release that cannot work.

`test`, `lint` and `build` pass here. Gzipped `umd.js` goes from 3005 to 3056 bytes (bundlewatch limit is 3072). Together with #235 it is around 3067 bytes, so maybe you want to raise the limit.

Closes #234
